### PR TITLE
Set metrics.enabled=true for Crossplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Roughly:
   a. `package/xclusters.test.crossplane.io/composition-gcp.yaml`
   b. `package/xclusters.test.crossplane.io/definition.yaml`
   c. `cluster-gcp.yaml`.
-2. Deploy Crossplane to said GKE cluster (e.g. `up uxp install`).
+2. Deploy Crossplane to said GKE cluster (e.g. `up uxp install --set metrics.enabled=true`).
 3. Apply https://github.com/prometheus-operator/kube-prometheus/tree/release-0.9/manifests
 4. Apply https://raw.githubusercontent.com/caicloud/event_exporter/master/deploy/deploy.yml
 5. Apply `prom-pod-monitors.yaml`.
@@ -59,7 +59,7 @@ curl -sL https://cli.upbound.io | sh
 
 # Install Crossplane. We need 1.9.0-up.3 or above.
 # See https://github.com/upbound/universal-crossplane
-up uxp install 1.9.0-up.3
+up uxp install 1.9.0-up.3 --set metrics.enabled=true
 
 # You'll want kubectl v1.25.0 or above to avoid slowness due to too many CRDs
 # per https://blog.upbound.io/scaling-kubernetes-to-thousands-of-crds/


### PR DESCRIPTION
When I tried to run this repository to understand the issue [#2645](https://github.com/crossplane/crossplane/issues/2645) at Crossplane I could not see any data at Grafana dashboard and there were no proper data at Prometheus also. Crossplane's PodMonitor was using to `metrics` port but when I looked Crossplane's yaml I couldn't see any metrics port definition and checked the helm reference.

At the [Crossplane Helm Reference](https://docs.crossplane.io/v1.15/software/install/#customize-the-crossplane-helm-chart) it says that `metrics.enabled=false` by default. When we run `up uxp install` it creates a Crossplane deployment with `metrics.enabled=false` and it does not send any metrics to prometheus i.e. running the guide doesn't give a properly functioning Grafana dashboard.

I updated this guide accordingly and set the `metrics.enabled=true` since I believe one of the purposes of this repository is to see the metrics via Grafana while scaling.